### PR TITLE
feat: Add popover for objectFlags like flags

### DIFF
--- a/src/compiler/CompilerApi.ts
+++ b/src/compiler/CompilerApi.ts
@@ -11,6 +11,7 @@ export interface CompilerApi {
     SyntaxKind: typeof ts.SyntaxKind;
     ModuleKind: typeof ts.ModuleKind;
     NodeFlags: typeof ts.NodeFlags;
+    ObjectFlags: typeof ts.ObjectFlags;
     SymbolFlags: typeof ts.SymbolFlags;
     TypeFlags: typeof ts.TypeFlags;
     tsAstViewer: {
@@ -31,6 +32,7 @@ export type CompilerOptions = ts.CompilerOptions;
 export type ScriptTarget = ts.ScriptTarget;
 export type ScriptKind = ts.ScriptKind;
 export type NodeFlags = ts.NodeFlags;
+export type ObjectFlags = ts.ObjectFlags;
 export type SymbolFlags = ts.SymbolFlags;
 export type TypeFlags = ts.TypeFlags;
 export type SyntaxKind = ts.SyntaxKind;

--- a/src/components/PropertiesViewer.tsx
+++ b/src/components/PropertiesViewer.tsx
@@ -239,6 +239,8 @@ function getProperties(api: CompilerApi, rootItem: any) {
                         return getEnumFlagElement(api.NodeFlags, value);
                 }
             }
+            if (isTsType(parent) && key === "objectFlags")
+                return getEnumFlagElement(api.ObjectFlags, value);
             if (isTsType(parent) && key === "flags")
                 return getEnumFlagElement(api.TypeFlags, value);
             if (isTsSymbol(parent) && key === "flags")


### PR DESCRIPTION
Simple change, I just wanted to see the object flags rendered the same way flags were. I tested in 3.5.1 and 2.6.2 and confirmed the relevant enum is present in both versions.