### PR TITLE
Add support for receiving TypeScript Playground URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "circular-json": "^0.5.9",
+    "lz-string": "^1.4.4",
     "monaco-editor": "^0.17.1",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
@@ -61,6 +62,7 @@
     "@types/glob": "^7.1.1",
     "@types/inline-style-prefixer": "^5.0.0",
     "@types/jest": "^24.0.17",
+    "@types/lz-string": "^1.3.33",
     "@types/node": "^12.7.2",
     "@types/react": "^16.9.2",
     "@types/react-dom": "^16.8.5",

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ Source code for https://ts-ast-viewer.com
 # install
 yarn install
 
-# run locally
+# run locally, this can take a long time to boot up
 yarn start
 
 # run unit tests

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,13 +11,21 @@ import "./external/react-splitpane.css";
 import { ApiLoadingState } from "./types";
 import { appReducer } from "./reducers";
 import { StateSaver } from "./utils";
+import { decompressFromEncodedURIComponent } from "lz-string"
 
 const initialScriptTarget: ScriptTarget = 6 /* Latest */;
 const initialScriptKind: ScriptKind = 4 /* TSX */;
 const stateSaver = new StateSaver();
+
+let initialCode = ""
+if (document.location.hash && document.location.hash.startsWith("#code")) {
+    const code = document.location.hash.replace("#code/", "").trim();
+    initialCode = decompressFromEncodedURIComponent(code);
+}
+
 const store = createStore(appReducer, {
     apiLoadingState: ApiLoadingState.Loading,
-    code: "",
+    code: initialCode,
     options: {
         compilerPackageName: "typescript",
         treeMode: stateSaver.get().treeMode,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1168,6 +1168,11 @@
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
 
+"@types/lz-string@^1.3.33":
+  version "1.3.33"
+  resolved "https://registry.yarnpkg.com/@types/lz-string/-/lz-string-1.3.33.tgz#de2d6105ea7bcaf67dd1d9451d580700d30473fc"
+  integrity sha512-yWj3OnlKlwNpq9+Jh/nJkVAD3ta8Abk2kIRpjWpVkDlAD43tn6Q6xk5hurp84ndcq54jBDBGCD/WcIR0pspG0A==
+
 "@types/minimatch@*", "@types/minimatch@^3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -5559,6 +5564,11 @@ lru-cache@^5.1.1:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
   dependencies:
     yallist "^3.0.2"
+
+lz-string@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
+  integrity sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=
 
 make-dir@^2.0.0, make-dir@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
I'd like to add an "export to ts-ast-viewer" function the typescript playground, to do that I need to be able to send over URLs with potentially long strings. So this PR uses the exact same format for URLs as the playground. I didn't add a way to set the hash on your own site (that code would [look like this](https://github.com/orta/typescript-play/blob/016b93e18e121acf0854d4243d530a7b3db24c45/public/main-0.js#L647-L649) mainly cause I wasn't sure where you'd want that, or if you wanted it auto etc) 

WRT the new dep, this is the same dependency we use which I audited as being solid back then.