### PR TITLE
show control flow analysis

### DIFF
--- a/src/compiler/CompilerApi.ts
+++ b/src/compiler/CompilerApi.ts
@@ -14,6 +14,7 @@ export interface CompilerApi {
     ObjectFlags: typeof ts.ObjectFlags;
     SymbolFlags: typeof ts.SymbolFlags;
     TypeFlags: typeof ts.TypeFlags;
+    FlowFlags: typeof ts.FlowFlags;
     tsAstViewer: {
         packageName: CompilerPackageNames;
         cachedSourceFiles: { [name: string]: SourceFile | undefined };
@@ -42,3 +43,4 @@ export type CompilerHost = ts.CompilerHost;
 export type ReadonlyMap<T> = ts.ReadonlyMap<T>;
 export type Iterator<T> = ts.Iterator<T>;
 export type CommentRange = ts.CommentRange;
+export type FlowNode = ts.FlowNode;


### PR DESCRIPTION
control flow analysis is not exposed in public API, but it's helpful to visualize when we want to work on the typescript compiler. [Preview](http://ethereal-protest.surge.sh/#code/GYVwdgxgLglg9mABAJwKYAdUEMoAoIAWANIgDapgDmUBAlIgN4BQiriMwi+BAdGpjnrM2IlKighkSclRqIAfIgAMiAPyJCfDNjwzqdRAC5EAIhMBuFmwC+V1gDcsyRAGdEAXlMW7iAO4EYci4XHj05AB4yCn0hHxE3AGpPQksRWxE0CSlXS2sgA)

![image](https://user-images.githubusercontent.com/6630042/114263195-baddfb00-9a16-11eb-84b8-b8588afe0b56.png)
