### PR TITLE
Add powers of 2 to printed enum members if applicable

### DIFF
--- a/site/src/utils/__tests/getEnumFlagNames.test.ts
+++ b/site/src/utils/__tests/getEnumFlagNames.test.ts
@@ -4,7 +4,7 @@ import { getEnumFlagNames } from "../getEnumFlagNames";
 describe("getEnumFlagNames", () => {
   it("should get the flag names", () => {
     expect(getEnumFlagNames(ts.SymbolFlags, 512)).toEqual([
-      "ValueModule",
+      "ValueModule (2 ^ 9)",
       "All",
       "ParameterExcludes",
       "Namespace",

--- a/site/src/utils/getEnumFlagNames.ts
+++ b/site/src/utils/getEnumFlagNames.ts
@@ -1,9 +1,16 @@
 export function getEnumFlagNames(enumObj: any, flags: number) {
   const allFlags = Object.keys(enumObj)
-    .map(k => enumObj[k]).filter(v => typeof v === "number") as number[];
-  const matchedFlags = allFlags.filter(f => (f & flags) !== 0);
+    .map((k) => enumObj[k])
+    .filter((v) => typeof v === "number") as number[];
+  const matchedFlags = allFlags.filter((f) => (f & flags) !== 0);
 
   return matchedFlags
     .filter((f, i) => matchedFlags.indexOf(f) === i)
-    .map(f => enumObj[f]);
+    .map((f) => {
+      const power = Math.log2(f);
+      if (Number.isInteger(power)) {
+        return `${enumObj[f]} (2 ^ ${power})`;
+      }
+      return enumObj[f];
+    });
 }


### PR DESCRIPTION
Something I've wanted a few times, this makes noticing which flags are important easier, particularly when looking at symbol flags.