### PR TITLE
Add support for checkFlags enum

### DIFF
--- a/site/src/App.css
+++ b/site/src/App.css
@@ -269,3 +269,7 @@ a:visited {
 .propertiesViewer .array > .value {
   padding-left: 7px;
 }
+
+.treeViewLabel {
+  cursor: pointer;
+}

--- a/site/src/compiler/CompilerApi.ts
+++ b/site/src/compiler/CompilerApi.ts
@@ -15,6 +15,8 @@ export interface CompilerApi {
   SymbolFlags: typeof ts.SymbolFlags;
   TypeFlags: typeof ts.TypeFlags;
   FlowFlags: typeof ts.FlowFlags;
+  // Internal enum
+  CheckFlags: {};
   tsAstViewer: {
     packageName: CompilerPackageNames;
     cachedSourceFiles: { [name: string]: SourceFile | undefined };

--- a/site/src/components/LazyTreeView.tsx
+++ b/site/src/components/LazyTreeView.tsx
@@ -3,14 +3,16 @@ import TreeView from "react-treeview";
 
 export interface LazyTreeViewProps {
   defaultCollapsed: boolean;
-  nodeLabel: React.ReactNode;
+  nodeLabel: string | undefined;
   getChildren: () => JSX.Element;
 }
 
 export function LazyTreeView(props: LazyTreeViewProps) {
   const [isCollapsed, setIsCollapsed] = useState(props.defaultCollapsed);
 
-  return <TreeView nodeLabel={props.nodeLabel} collapsed={isCollapsed} onClick={toggleState}>{isCollapsed ? undefined : props.getChildren()}</TreeView>;
+  const label = <span className="treeViewLabel" onClick={toggleState}>{props.nodeLabel}</span>
+
+  return <TreeView nodeLabel={label} collapsed={isCollapsed} onClick={toggleState}>{isCollapsed ? undefined : props.getChildren()}</TreeView>;
 
   function toggleState() {
     setIsCollapsed(!isCollapsed);

--- a/site/src/components/PropertiesViewer.tsx
+++ b/site/src/components/PropertiesViewer.tsx
@@ -324,6 +324,10 @@ function getCustomValueDiv(context: Context, key: string, value: any, parent: an
     if (isTsSymbol(parent) && key === "flags") {
       return getEnumFlagElement(context.api.SymbolFlags, value);
     }
+    // TS pre-5.0 puts this on the symbol, TS 5.0 puts it on a plain "links" object
+    if (key === "checkFlags" && typeof value === "number") {
+      return getEnumFlagElement(context.api.CheckFlags, value);
+    }
     if (isFlowNode(parent) && key === "flags") {
       return getEnumFlagElement(context.api.FlowFlags, value);
     }


### PR DESCRIPTION
Also adds support for clicking on a collapsed tree view label to expand it rather than having to click on the small arrow next to the label. This only applies to the lazy tree view, not the one used to display nodes, since there's already another behavior associated with clicking on that label.