### PR TITLE
Update Monaco

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -13,10 +13,10 @@
     "@ts-ast-viewer/shared": "^1.0.0",
     "circular-json": "^0.5.9",
     "lz-string": "^1.4.4",
-    "monaco-editor": "^0.34.1",
+    "monaco-editor": "^0.37.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-monaco-editor": "0.51.0",
+    "react-monaco-editor": "0.52.0",
     "react-spinners": "^0.13.6",
     "react-split-pane": "^0.1.92",
     "react-treeview": "^0.4.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2879,10 +2879,10 @@ mkdirp@^1.0.4:
   resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-monaco-editor@^0.34.1:
-  version "0.34.1"
-  resolved "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.34.1.tgz"
-  integrity sha512-FKc80TyiMaruhJKKPz5SpJPIjL+dflGvz4CpuThaPMc94AyN7SeC9HQ8hrvaxX7EyHdJcUY5i4D0gNyJj1vSZQ==
+monaco-editor@^0.37.1:
+  version "0.37.1"
+  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.37.1.tgz#d6f5ffb593e019e74e19bf8a2bdef5a691876f4e"
+  integrity sha512-jLXEEYSbqMkT/FuJLBZAVWGuhIb4JNwHE9kPTorAVmsdZ4UzHAfgWxLsVtD7pLRFaOwYPhNG9nUCpmFL1t/dIg==
 
 ms@2.1.2:
   version "2.1.2"
@@ -3164,10 +3164,10 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-monaco-editor@0.51.0:
-  version "0.51.0"
-  resolved "https://registry.npmjs.org/react-monaco-editor/-/react-monaco-editor-0.51.0.tgz"
-  integrity sha512-6jx1V8p6gHVKJHFaTvicOtmlhFjOJhekobeNd92ZAo7F5UvAin1cF7bxWLCKgtxClYZ7CB3Ar284Kpbhj22FpQ==
+react-monaco-editor@0.52.0:
+  version "0.52.0"
+  resolved "https://registry.yarnpkg.com/react-monaco-editor/-/react-monaco-editor-0.52.0.tgz#69a7c450a22830064d2fc1b446674b1b7da0f540"
+  integrity sha512-jhQSekf2JABbcpN45gKZlWfTS0QcBOZAbAWKGyfqy/KEcMXTwJpCOYGcn2Ur11SUUxWJUzhKjE2fx9BGBc5S8g==
   dependencies:
     prop-types "^15.8.1"
 


### PR DESCRIPTION
In the version of Monaco currently deployed, this code has language service errors, but it's fine according to TS.

```ts
export class TypeEmitter<T, TOptions extends object = Record<string, never>> {
    
}

export function createAssetEmitter<T, TOptions extends object>(
  TypeEmitterClass: typeof TypeEmitter<T, TOptions>
): void {
    TypeEmitterClass;
}
```

I still want #69, but this was easier for now