### PR TITLE
Use blue for the selected color in light mode

### DIFF
--- a/site/src/App.css
+++ b/site/src/App.css
@@ -46,7 +46,7 @@ body,
   --header-background: #ececec;
   --tooltip-background: #f1f1f1;
   --range-highlight: #d1d1d1;
-  --node-selected: #84b327;
+  --node-selected: #007acc;
   --internal-prop: #ed1111;
 
   --vscode-background: #fffffe;


### PR DESCRIPTION
I find the green doesn't pop out as much, so this uses the same blue as the vscode toolbar.