### PR TITLE
Handle TypeMapKind properties correctly

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -10,5 +10,5 @@ If you open up the developer console it will provide some compiler objects that 
 
 ## Additional Resources
 
-- [TypeScript Architectual Overview](https://github.com/microsoft/TypeScript/wiki/Architectural-Overview)
+- [TypeScript Architectural Overview](https://github.com/microsoft/TypeScript/wiki/Architectural-Overview)
 - [Using the Compiler API](https://github.com/Microsoft/TypeScript/wiki/Using-the-Compiler-API)

--- a/site/src/compiler/CompilerApi.ts
+++ b/site/src/compiler/CompilerApi.ts
@@ -20,6 +20,8 @@ export interface CompilerApi {
   CheckFlags: {};
   // Internal enum
   TransformFlags: {};
+  // Internal enum
+  TypeMapKind: {};
   tsAstViewer: {
     packageName: CompilerPackageNames;
     cachedSourceFiles: { [name: string]: SourceFile | undefined };

--- a/site/src/components/PropertiesViewer.tsx
+++ b/site/src/components/PropertiesViewer.tsx
@@ -336,6 +336,9 @@ function getCustomValueDiv(context: Context, key: string, value: any, parent: an
     if (key === "checkFlags" && typeof value === "number") {
       return getEnumFlagElement(context.api.CheckFlags, value);
     }
+    if (key === "kind" && typeof value === "number") {
+      return getEnumFlagElement(context.api.TypeMapKind, value);
+    }
     if (isFlowNode(parent) && key === "flags") {
       return getEnumFlagElement(context.api.FlowFlags, value);
     }
@@ -486,7 +489,7 @@ function isMap(value: any): value is ReadonlyMap<string, unknown> {
 }
 
 function isTsNode(value: any): value is Node {
-  return typeof (value as Node).kind === "number";
+  return typeof (value as Node).kind === "number" && typeof (value as Node).flags === "number";
 }
 
 function isTsType(value: any): value is Type {


### PR DESCRIPTION
See https://github.com/microsoft/TypeScript/blob/8f531ff3ba221344a93a63312326f9decfdcf458/src/compiler/types.ts#L6830-L6846

Previously, the property viewer was displaying this `kind` property as a `SyntaxKind`.

Per the TS types, nodes will always also have a `flags` property, while a `mapper` from a mapped type will not:

https://github.com/microsoft/TypeScript/blob/8f531ff3ba221344a93a63312326f9decfdcf458/src/compiler/types.ts#L932-L935

I skimmed through the other 230ish instances of `kind: ` in `types.ts` and it doesn't look like this will cause any conflicts.