### PR TITLE
Visualize FlowNode graph

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@ts-ast-viewer/shared": "^1.0.0",
+    "@viz-js/viz": "^3.3.1",
     "circular-json": "^0.5.9",
     "lz-string": "^1.4.4",
     "monaco-editor": "^0.37.1",

--- a/site/src/components/FlowNodeGraph.tsx
+++ b/site/src/components/FlowNodeGraph.tsx
@@ -1,0 +1,92 @@
+import React from "react";
+
+import { FlowFlags, FlowNode } from "typescript";
+import { EnumUtils, flagUtils } from "../utils";
+import { CompilerApi } from "../compiler";
+
+export interface DotGraphProps {
+  api: CompilerApi;
+  flowNode: FlowNode;
+}
+
+function quoted(txt: string): string {
+  return JSON.stringify(txt).slice(1, -1);
+}
+
+function getFlagText(api: CompilerApi, flags: FlowFlags) {
+  // These are optimizations, not semantic flags.
+  flags = flags & ~(FlowFlags.Shared | FlowFlags.Referenced);
+  switch (flags) {
+    case FlowFlags.TrueCondition:
+    case FlowFlags.FalseCondition:
+    case FlowFlags.Start:
+    case FlowFlags.Assignment:
+    case FlowFlags.BranchLabel:
+    case FlowFlags.LoopLabel:
+    case FlowFlags.Call:
+      return EnumUtils.getNamesForValues(api.FlowFlags).find(e => e.value === flags)!.names[0];
+  }
+  const flagElements = flagUtils.getEnumFlagLines(api.FlowFlags, flags);
+  const flagLines = flagElements ? flagElements.join("\\n") : String(flags);
+  return `flags=${flagLines.length > 1 ? '\\n' : ''}${flagLines}`;
+}
+
+function getDotForFlowGraph(api: CompilerApi, node: FlowNode) {
+  let nextId = 0;
+  const getNextId = () => nextId++;
+  const nodeIds = new Map<FlowNode, string>();
+  const idForNode = (n: FlowNode) => {
+    let id = nodeIds.get(n);
+    if (id !== undefined) {
+      return id;
+    }
+    id = 'n' + getNextId();
+    nodeIds.set(n, id);
+    return id;
+  };
+
+  const nodeLines = [];
+  const edgeLines = [];
+
+  const seen = new Set<FlowNode>();
+  let fringe = [node];
+  while (fringe.length) {
+    const fn = fringe[0];
+    fringe = fringe.slice(1);
+    if (seen.has(fn)) {
+      continue;
+    }
+    seen.add(fn);
+    const id = idForNode(fn);
+
+    let nodeText = null;
+    if ('node' in fn && fn.node) {
+      nodeText = fn.node.getText();
+    }
+
+    const flagText = getFlagText(api, fn.flags);
+    const parts = [];
+    if (nodeText) {
+      parts.push(quoted(nodeText));
+    }
+    parts.push(flagText);
+    nodeLines.push(`${id} [shape=record label="{${parts.join("|")}}"];`);
+    const antecedents = 'antecedent' in fn ? [fn.antecedent] : ('antecedents' in fn && fn.antecedents) ? fn.antecedents : [];
+    for (const antecedent of antecedents) {
+      fringe.push(antecedent);
+      const antId = idForNode(antecedent);
+      edgeLines.push(`${id} -> ${antId};`);
+    }
+  }
+
+  return `digraph {
+  rankdir="BT";
+${nodeLines.map(line => '  ' + line).join('\n')}
+${edgeLines.map(line => '  ' + line).join('\n')}
+}`;
+}
+
+export function DotGraph({flowNode, api}: DotGraphProps) {
+  const dot = React.useMemo(() => getDotForFlowGraph(api, flowNode), [flowNode]);
+  return <textarea rows={10} cols={40}>{dot}</textarea>;
+}

--- a/site/src/components/PropertiesViewer.tsx
+++ b/site/src/components/PropertiesViewer.tsx
@@ -17,10 +17,10 @@ import {
 } from "../compiler";
 import { BindingTools, CompilerState } from "../types";
 import { flagUtils, getSyntaxKindName } from "../utils";
+import { FlowNodeGraph } from "./FlowNodeGraph";
 import { LazyTreeView } from "./LazyTreeView";
 import { Spinner } from "./Spinner";
 import { ToolTippedText } from "./ToolTippedText";
-import { DotGraph } from "./FlowNodeGraph";
 
 export interface PropertiesViewerProps {
   compiler: CompilerState;
@@ -207,7 +207,7 @@ function getForFlowNode(context: Context, node: Node, typeChecker: TypeChecker) 
 
   return (
     <>
-      <DotGraph flowNode={flowNode} api={context.api} />
+      <FlowNodeGraph flowNode={flowNode} api={context.api} />
       {getTreeView(context, nodeWithFlowNode.flowNode, "FlowNode")}
     </>
   );
@@ -525,7 +525,7 @@ function getEnumFlagElement(enumObj: any, value: number) {
 
   return (
     <ToolTippedText text={value.toString()}>
-      <ul>{elements}</ul>
+      <ul>{elements.map((el, i) => <li key={i}>{el}</li>)}</ul>
     </ToolTippedText>
   );
 }

--- a/site/src/components/PropertiesViewer.tsx
+++ b/site/src/components/PropertiesViewer.tsx
@@ -202,7 +202,12 @@ function getForFlowNode(context: Context, node: Node, typeChecker: TypeChecker) 
     return <>[None]</>;
   }
 
-  return getTreeView(context, nodeWithFlowNode.flowNode, "FlowNode");
+  return (
+    <>
+      <h2>Dan is here</h2>
+      {getTreeView(context, nodeWithFlowNode.flowNode, "FlowNode")}
+    </>
+  );
 }
 
 function getOrReturnError<T>(getFunc: () => T): T | string {

--- a/site/src/utils/flags.ts
+++ b/site/src/utils/flags.ts
@@ -1,0 +1,16 @@
+import { ArrayUtils } from "./ArrayUtils";
+import { EnumUtils } from "./EnumUtils";
+
+export function getEnumFlagLines(enumObj: any, value: number): string[] | null {
+  const names = EnumUtils.getNamesForValues(enumObj).filter(entry => entry.value & value);
+  if (names.length === 0) {
+    return null;
+  }
+
+  const [powersOfTwo, others] = ArrayUtils.partition(names, ({ value }) => Number.isInteger(Math.log2(value)));
+
+  return [...powersOfTwo, ...others].flatMap(({ value, names }) => {
+    const power = Math.log2(value);
+    return names.map(name => Number.isInteger(power) ? `${name} (2 ^ ${power})` : name);
+  });
+}

--- a/site/src/utils/index.ts
+++ b/site/src/utils/index.ts
@@ -3,6 +3,7 @@ export * from "./assertNever";
 export * from "./Box";
 export * from "./createHashSet";
 export * from "./EnumUtils";
+export * as flagUtils from "./flags";
 export * from "./getSyntaxKindName";
 export * from "./LineAndColumnComputer";
 export * from "./sleep";

--- a/yarn.lock
+++ b/yarn.lock
@@ -941,6 +941,11 @@
     magic-string "^0.26.7"
     react-refresh "^0.14.0"
 
+"@viz-js/viz@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@viz-js/viz/-/viz-3.3.1.tgz#6ab51eeadbc784fbe3d3d9c4e64a9e66ed270bb5"
+  integrity sha512-W78mAW9oS+cV2240KIH84eCb57Js8oU+37LMzbFym7Fraouju1NHmRsJO2eTcnjFHSEQWG06z/m47fqsvMNPFg==
+
 acorn-walk@^8.1.1:
   version "8.2.0"
   resolved "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz"


### PR DESCRIPTION
This is significantly easier to understand than the antecedent tree view:

<img width="1266" alt="image" src="https://github.com/dsherret/ts-ast-viewer/assets/98301/9b631833-2101-4087-a4d1-c0934fbccf3a">

This does a BFS on the FlowNode graph (via `antecedent` / `antecedents`) and produces a graph spec using dot format. It then uses [viz-js](https://github.com/mdaines/viz-js) to turn this into an SVG for display.

If this is of interest, we can work on tuning the display, options and interactivity.

cc @JoshuaKGoldberg, who was interested in this