### PR TITLE
Always use light mode for external link

### DIFF
--- a/site/src/App.css
+++ b/site/src/App.css
@@ -304,3 +304,16 @@ a:visited {
 .treeViewLabel {
   cursor: pointer;
 }
+
+a[target="_blank"]::after {
+  content: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAQElEQVR42qXKwQkAIAxDUUdxtO6/RBQkQZvSi8I/pL4BoGw/XPkh4XigPmsUgh0626AjRsgxHTkUThsG2T/sIlzdTsp52kSS1wAAAABJRU5ErkJggg==);
+  margin: 0 3px 0 5px;
+}
+
+.App[data-theme="dark"] a[target="_blank"]::after {
+  filter: brightness(0) invert(1);
+}
+
+.graphLink {
+  font-size: small;
+}

--- a/site/src/components/FlowNodeGraph.tsx
+++ b/site/src/components/FlowNodeGraph.tsx
@@ -124,7 +124,18 @@ export function FlowNodeGraph({ flowNode, api }: FlowNodeGraphProps) {
   const { state } = useAppContext();
   const darkMode = state.editorTheme === "dark";
   const dot = React.useMemo(() => getDotForFlowGraph(api, flowNode, darkMode), [flowNode, darkMode]);
-  // todo: make this work with dark mode
-  // const url = "https://dreampuf.github.io/GraphvizOnline/#" + encodeURI(dot);
-  return <DotViz dot={dot} />;
+  // GraphvizOnline doesn't have a dark mode, so always use light mode for the external link.
+  const dotLight = React.useMemo(
+    () => !darkMode ? dot : getDotForFlowGraph(api, flowNode, false),
+    [darkMode, dot, api, flowNode],
+  );
+  const url = "https://dreampuf.github.io/GraphvizOnline/#" + encodeURI(dotLight);
+  return (
+    <>
+      <DotViz dot={dot} />
+      <div className="graphLink">
+        <a href={url} target="_blank" rel="noopener">View Graph</a>
+      </div>
+    </>
+  );
 }


### PR DESCRIPTION
Follow-on to #139 

The external link is always in light mode. If you also use TS AST Viewer in light mode, we'll only generate the DOT once.

Here's what the link looks like:

<img width="294" alt="image" src="https://github.com/dsherret/ts-ast-viewer/assets/98301/606ca21f-6bb6-4a8f-962e-e2529d83a9ee">
