### PR TITLE
Use monospace as default font

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -9,7 +9,7 @@ html,
 body {
   margin: 0;
   padding: 0;
-  font-family: sans-serif;
+  font-family: monospace;
 }
 
 html,


### PR DESCRIPTION
Hello! I couldn't find an issue about this, but I am curious if you are open to switching the primary font from sans-serif to monospace to make reading the AST and its properties a little bit easier (IMO).

<img width="1189" alt="Screenshot 2024-05-03 at 12 24 44 PM" src="https://github.com/dsherret/ts-ast-viewer/assets/2344137/3234378d-8361-4610-84ed-73f7db0bf656">
<img width="1189" alt="Screenshot 2024-05-03 at 12 25 03 PM" src="https://github.com/dsherret/ts-ast-viewer/assets/2344137/ad0b8240-77e4-42fb-bd60-881daa806cd8">

If you are open to this and/or would want it to be configurable, let me know and I'd be happy to make some changes.