### PR TITLE
Handle both single and multiple antecedents in "antecedent" field

### DIFF
--- a/src/components/FlowNodeGraph.tsx
+++ b/src/components/FlowNodeGraph.tsx
@@ -81,7 +81,7 @@ function getDotForFlowGraph(api: CompilerApi, node: FlowNode, darkMode: boolean)
     parts.push(flagText);
     nodeLines.push(`${id} [shape=record ${nodeProps} label="{${parts.join("|")}}"];`);
     const antecedents = "antecedent" in fn && fn.antecedent != null
-      ? [fn.antecedent]
+      ? Array.isArray(fn.antecedent) ? fn.antecedent : [fn.antecedent]
       : ("antecedents" in fn && fn.antecedents)
       ? fn.antecedents
       : [];


### PR DESCRIPTION
TS v5.5 changed some stuff regarding flow types. One thing is that the `antecedent` field could be an array now.

In fact, examples like [this](https://ts-ast-viewer.com/#code/GYVwdgxgLglg9mABAGznADgCgJSIN4BQiKAplIgB6IC8iAjANxGIDuAFjMiYplQDz0A+gAZRI0bkLFiVAFS0ATE2mIICAM5wuAOlQBzXtmWIAvswBOZEOaQUmJoA) are quite broken now. If you select the last `return x`, for example, you see that TS version `5.5` has renamed the `antecedents` field containing an array into `antecedent`.