### PR TITLE
fix: issue FlowNode graph of switch-case broken on TS 5.5.x #158

### DIFF
--- a/src/components/FlowNodeGraph.tsx
+++ b/src/components/FlowNodeGraph.tsx
@@ -66,7 +66,7 @@ function getDotForFlowGraph(api: CompilerApi, node: FlowNode, darkMode: boolean)
     const id = idForNode(fn);
 
     let nodeText = null;
-    if ("node" in fn && fn.node) {
+    if ("node" in fn && fn.node && typeof fn.node?.getText === "function") {
       nodeText = fn.node.getText();
       if (nodeText.length > 50) {
         nodeText = nodeText.slice(0, 45) + "…";


### PR DESCRIPTION
The rendering logic wasn't supporting the text from switch statements before, that is `fn.switchStatement` wasn't used in any way, so I keep ignoring it.

Fixes #158 