### PR TITLE
Add support for multiple files

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -210,7 +210,20 @@ a:visited {
   margin-right: 8px;
 }
 
+/* Current file controller line */
+
+#filesControl {
+  height: 24px;
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 8px;
+}
+
 /* Code Editor */
+
+#codeEditor {
+  height: calc(100% - 24px);
+}
 
 .codeEditor {
   width: 100%;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,13 +52,19 @@ export function App() {
       return (
         <Allotment vertical>
           <Allotment.Pane preferredSize="70%">
+            {getFilesControl()}
             {getCodeEditor()}
           </Allotment.Pane>
           {getFactoryCodeEditor()}
         </Allotment>
       );
     } else {
-      return getCodeEditor();
+      return (
+        <>
+          {getFilesControl()}
+          {getCodeEditor()}
+        </>
+      );
     }
 
     function getFactoryCodeEditor() {
@@ -67,9 +73,25 @@ export function App() {
       }
 
       return (
-        <components.ErrorBoundary getResetHash={() => state.code}>
+        <components.ErrorBoundary getResetHash={() => state.files[state.currentFile]}>
           <components.FactoryCodeEditor compiler={compiler} theme={state.editorTheme} />
         </components.ErrorBoundary>
+      );
+    }
+
+    function getFilesControl() {
+      return (
+        <components.FilesControl
+          files={state.files}
+          currentFile={state.currentFile}
+          onChange={(file) => {
+            if (!file) {
+              dispatch({ type: "DELETE_CURRENT_FILE" });
+            } else {
+              dispatch({ type: "SET_CURRENT_FILE", file });
+            }
+          }}
+        />
       );
     }
 
@@ -91,7 +113,7 @@ export function App() {
             dispatch({ type: "SET_SELECTED_NODE", node: descendant });
           }}
           theme={state.editorTheme}
-          text={state.code}
+          text={state.files[state.currentFile]}
           highlight={getCodeHighlightRange()}
           showInfo
           renderWhiteSpace

--- a/src/AppContext.tsx
+++ b/src/AppContext.tsx
@@ -4,7 +4,6 @@ import {
   compilerVersionCollection,
   getCompilerApi,
   hasLoadedCompilerApi,
-  type ScriptKind,
   type ScriptTarget,
 } from "./compiler/index.js";
 import type { CodeEditorTheme } from "./components/index.js";
@@ -13,7 +12,6 @@ import { ApiLoadingState, type StoreState } from "./types/index.js";
 import { sleep, StateSaver, UrlSaver } from "./utils/index.js";
 
 const initialScriptTarget: ScriptTarget = 99 /* Latest */;
-const initialScriptKind: ScriptKind = 4 /* TSX */;
 const stateSaver = new StateSaver();
 
 console.log(
@@ -28,14 +26,17 @@ export interface AppContextValue {
 export const AppContext = React.createContext<AppContextValue | undefined>(undefined);
 
 export function AppContextProvider({ children }: { children: React.ReactNode }) {
+  // Guaranteed to have at least one property
+  const urlFiles = new UrlSaver().getUrlFiles();
+
   const [state, dispatch] = useReducer(appReducer, {
     apiLoadingState: ApiLoadingState.Loading,
-    code: new UrlSaver().getUrlCode(),
+    currentFile: Object.keys(urlFiles)[0],
+    files: urlFiles,
     options: {
       compilerPackageName: compilerVersionCollection[0].packageName,
       treeMode: stateSaver.get().treeMode,
       scriptTarget: initialScriptTarget,
-      scriptKind: initialScriptKind,
       bindingEnabled: true,
       showFactoryCode: stateSaver.get().showFactoryCode,
       showInternals: stateSaver.get().showInternals,
@@ -87,8 +88,8 @@ export function AppContextProvider({ children }: { children: React.ReactNode }) 
       }
     }
   }, [
-    state.code,
-    state.options.scriptKind,
+    state.currentFile,
+    state.files[state.currentFile],
     state.options.scriptTarget,
     state.options.compilerPackageName,
     state.options.bindingEnabled,

--- a/src/actions/index.tsx
+++ b/src/actions/index.tsx
@@ -14,6 +14,15 @@ export function setCode(code: string): SetCode {
   };
 }
 
+export interface SetCurrentFile {
+  type: constants.SET_CURRENT_FILE;
+  file: string;
+}
+
+export interface DeleteCurrentFile {
+  type: constants.DELETE_CURRENT_FILE;
+}
+
 export interface SetApiLoadingState {
   type: constants.SET_API_LOADING_STATE;
   loadingState: ApiLoadingState;
@@ -74,6 +83,8 @@ export function osThemeChange(): OsThemeChange {
 
 export type AllActions =
   | SetCode
+  | SetCurrentFile
+  | DeleteCurrentFile
   | SetApiLoadingState
   | RefreshSourceFile
   | SetSelectedNode

--- a/src/compiler/CompilerApi.ts
+++ b/src/compiler/CompilerApi.ts
@@ -20,7 +20,6 @@ export interface CompilerApi {
   getDefaultLibFileName: typeof ts.getDefaultLibFileName;
   forEachChild: typeof ts.forEachChild;
   ScriptTarget: typeof ts.ScriptTarget;
-  ScriptKind: typeof ts.ScriptKind;
   SyntaxKind: typeof ts.SyntaxKind;
   ModifierFlags: typeof ts.ModifierFlags;
   ModuleKind: typeof ts.ModuleKind;
@@ -53,7 +52,6 @@ export type Program = ts.Program;
 export type TypeChecker = ts.TypeChecker;
 export type CompilerOptions = ts.CompilerOptions;
 export type ScriptTarget = ts.ScriptTarget;
-export type ScriptKind = ts.ScriptKind;
 export type NodeFlags = ts.NodeFlags;
 export type ObjectFlags = ts.ObjectFlags;
 export type SymbolFlags = ts.SymbolFlags;

--- a/src/compiler/CompilerApi.ts
+++ b/src/compiler/CompilerApi.ts
@@ -23,6 +23,8 @@ export interface CompilerApi {
   SyntaxKind: typeof ts.SyntaxKind;
   ModifierFlags: typeof ts.ModifierFlags;
   ModuleKind: typeof ts.ModuleKind;
+  ModuleResolutionKind: typeof ts.ModuleResolutionKind;
+  JsxEmit: typeof ts.JsxEmit;
   NodeFlags: typeof ts.NodeFlags;
   ObjectFlags: typeof ts.ObjectFlags;
   SymbolFlags: typeof ts.SymbolFlags;

--- a/src/compiler/convertOptions.test.ts
+++ b/src/compiler/convertOptions.test.ts
@@ -3,28 +3,22 @@ import { Theme } from "../types/index.js";
 import type { CompilerApi } from "./CompilerApi.js";
 import { convertOptions } from "./convertOptions.js";
 
-function getCompilerApi(scriptKind: any, scriptTarget: any) {
+function getCompilerApi(scriptTarget: any) {
   return {
-    ScriptKind: scriptKind,
     ScriptTarget: scriptTarget,
   } as any as CompilerApi;
 }
 
-function doTest(fromKind: number, fromTarget: number, expectedKind: number, expectedTarget: number) {
-  // deno-fmt-ignore
-  enum ScriptKindFrom { TSX, JSX, Extra }
-  // deno-fmt-ignore
-  enum ScriptKindTo { JSX, TSX }
+function doTest(fromTarget: number, expectedTarget: number) {
   // deno-fmt-ignore
   enum ScriptTargetFrom { ES5, Latest, Extra }
   // deno-fmt-ignore
   enum ScriptTargetTo { Latest, ES5 }
-  const apiFrom = getCompilerApi(ScriptKindFrom, ScriptTargetFrom);
-  const apiTo = getCompilerApi(ScriptKindTo, ScriptTargetTo);
+  const apiFrom = getCompilerApi(ScriptTargetFrom);
+  const apiTo = getCompilerApi(ScriptTargetTo);
 
   expect(convertOptions(apiFrom, apiTo, {
     compilerPackageName: "typescript-4.4.4" as any,
-    scriptKind: fromKind,
     scriptTarget: fromTarget,
     treeMode: 0,
     bindingEnabled: true,
@@ -33,7 +27,6 @@ function doTest(fromKind: number, fromTarget: number, expectedKind: number, expe
     theme: Theme.Dark,
   })).toEqual({
     compilerPackageName: "typescript-4.4.4" as any,
-    scriptKind: expectedKind,
     scriptTarget: expectedTarget,
     treeMode: 0,
     bindingEnabled: true,
@@ -44,9 +37,9 @@ function doTest(fromKind: number, fromTarget: number, expectedKind: number, expe
 }
 
 Deno.test("should convert between the options when they all exist", () => {
-  doTest(0, 0, 1, 1);
+  doTest(0, 1);
 });
 
 Deno.test("should convert between the options when they don't exist", () => {
-  doTest(2, 2, 1, 0);
+  doTest(2, 0);
 });

--- a/src/compiler/convertOptions.ts
+++ b/src/compiler/convertOptions.ts
@@ -1,5 +1,5 @@
 import type { OptionsState } from "../types/index.js";
-import type { CompilerApi, ScriptKind, ScriptTarget } from "./CompilerApi.js";
+import type { CompilerApi, ScriptTarget } from "./CompilerApi.js";
 
 export function convertOptions(apiFrom: CompilerApi | undefined, apiTo: CompilerApi, options: OptionsState) {
   if (apiFrom == null || apiFrom === apiTo) {
@@ -7,11 +7,9 @@ export function convertOptions(apiFrom: CompilerApi | undefined, apiTo: Compiler
   }
 
   const scriptTarget = apiTo.ScriptTarget[apiFrom.ScriptTarget[options.scriptTarget] as any] as any as ScriptTarget;
-  const scriptKind = apiTo.ScriptKind[apiFrom.ScriptKind[options.scriptKind] as any] as any as ScriptKind;
 
   return {
     ...options,
     scriptTarget: scriptTarget == null ? apiTo.ScriptTarget.Latest : scriptTarget,
-    scriptKind: scriptKind == null ? apiTo.ScriptKind.TSX : scriptKind,
   };
 }

--- a/src/compiler/createSourceFile.ts
+++ b/src/compiler/createSourceFile.ts
@@ -11,7 +11,7 @@ import type {
 export function createSourceFiles(api: CompilerApi, files: Record<string, string>, scriptTarget: ScriptTarget) {
   const sourceFiles: Record<string, SourceFile> = Object.fromEntries(
     Object.entries(files).map(([name, code]) => {
-      return [name, api.createSourceFile(`/${name}`, code, scriptTarget, false)];
+      return [name, api.createSourceFile(name, code, scriptTarget, false)];
     }),
   );
   let bindingResult: { typeChecker: TypeChecker; program: Program } | undefined;

--- a/src/compiler/createSourceFile.ts
+++ b/src/compiler/createSourceFile.ts
@@ -1,21 +1,22 @@
-import { assertNever } from "../utils/index.js";
 import type {
   CompilerApi,
   CompilerHost,
   CompilerOptions,
   Program,
-  ScriptKind,
   ScriptTarget,
   SourceFile,
   TypeChecker,
 } from "./CompilerApi.js";
 
-export function createSourceFile(api: CompilerApi, code: string, scriptTarget: ScriptTarget, scriptKind: ScriptKind) {
-  const filePath = `/ts-ast-viewer${getExtension(api, scriptKind)}`;
-  const sourceFile = api.createSourceFile(filePath, code, scriptTarget, false, scriptKind);
+export function createSourceFiles(api: CompilerApi, files: Record<string, string>, scriptTarget: ScriptTarget) {
+  const sourceFiles: Record<string, SourceFile> = Object.fromEntries(
+    Object.entries(files).map(([name, code]) => {
+      return [name, api.createSourceFile(`/${name}`, code, scriptTarget, false)];
+    }),
+  );
   let bindingResult: { typeChecker: TypeChecker; program: Program } | undefined;
 
-  return { sourceFile, bindingTools: getBindingTools };
+  return { sourceFiles, bindingTools: getBindingTools };
 
   // binding may be disabled, so make this deferred
   function getBindingTools() {
@@ -30,10 +31,12 @@ export function createSourceFile(api: CompilerApi, code: string, scriptTarget: S
       strict: true,
       target: scriptTarget,
       allowJs: true,
-      module: api.ModuleKind.ES2015,
+      module: api.ModuleKind.NodeNext,
+      moduleResolution: 99,
+      jsx: 1,
     };
     const files: { [name: string]: SourceFile | undefined } = {
-      [filePath]: sourceFile,
+      ...sourceFiles,
       ...api.tsAstViewer.cachedSourceFiles,
     };
 
@@ -50,7 +53,7 @@ export function createSourceFile(api: CompilerApi, code: string, scriptTarget: S
       getCurrentDirectory: () => "/",
       getDirectories: (_path: string) => [],
       fileExists: (fileName: string) => files[fileName] != null,
-      readFile: (fileName: string) => files[fileName] != null ? files[fileName]!.getFullText() : undefined,
+      readFile: (fileName: string) => files[fileName]?.getFullText(),
       getCanonicalFileName: (fileName: string) => fileName,
       useCaseSensitiveFileNames: () => true,
       getNewLine: () => "\n",
@@ -60,26 +63,5 @@ export function createSourceFile(api: CompilerApi, code: string, scriptTarget: S
     const typeChecker = program.getTypeChecker();
 
     return { typeChecker, program };
-  }
-}
-
-function getExtension(api: CompilerApi, scriptKind: ScriptKind) {
-  switch (scriptKind) {
-    case api.ScriptKind.TS:
-      return ".ts";
-    case api.ScriptKind.TSX:
-      return ".tsx";
-    case api.ScriptKind.JS:
-      return ".js";
-    case api.ScriptKind.JSX:
-      return ".jsx";
-    case api.ScriptKind.JSON:
-      return ".json";
-    case api.ScriptKind.External:
-    case api.ScriptKind.Deferred:
-    case api.ScriptKind.Unknown:
-      return "";
-    default:
-      return assertNever(scriptKind, `Not implemented ScriptKind: ${api.ScriptKind[scriptKind]}`);
   }
 }

--- a/src/compiler/createSourceFile.ts
+++ b/src/compiler/createSourceFile.ts
@@ -32,8 +32,8 @@ export function createSourceFiles(api: CompilerApi, files: Record<string, string
       target: scriptTarget,
       allowJs: true,
       module: api.ModuleKind.NodeNext,
-      moduleResolution: 99,
-      jsx: 1,
+      moduleResolution: api.ModuleResolutionKind.NodeNext,
+      jsx: api.JsxEmit.Preserve,
     };
     const files: { [name: string]: SourceFile | undefined } = {
       ...sourceFiles,

--- a/src/compiler/getCompilerApi.ts
+++ b/src/compiler/getCompilerApi.ts
@@ -39,8 +39,6 @@ async function loadCompilerApi(packageName: CompilerPackageNames) {
   function getLibSourceFiles() {
     return Object.keys(libFiles)
       .map((key) => (libFiles as any)[key] as { fileName: string; text: string })
-      .map((libFile) =>
-        api.createSourceFile(libFile.fileName, libFile.text, api.ScriptTarget.Latest, false, api.ScriptKind.TS)
-      );
+      .map((libFile) => api.createSourceFile(libFile.fileName, libFile.text, api.ScriptTarget.Latest, false));
   }
 }

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -52,7 +52,7 @@ export class CodeEditor extends React.Component<CodeEditorProps, CodeEditorState
 
       reactMonacoEditorPromise.then((editor) => {
         // types are wrong for this package
-        this.setState({ editorComponent: (editor.default as any) });
+        this.setState({ editorComponent: editor.default as any });
       }).catch((err) => {
         console.error(err);
         this.setState({ editorComponent: false });

--- a/src/components/FilesControl.tsx
+++ b/src/components/FilesControl.tsx
@@ -1,0 +1,40 @@
+import type React from "react";
+
+export function FilesControl(
+  props: { files: Record<string, string>; currentFile: string; onChange: (file: string | undefined) => void },
+): React.ReactElement {
+  return (
+    <div id="filesControl">
+      <select value={props.currentFile} onChange={onChangeFile}>
+        {Object.keys(props.files).map((f) => <option key={f} value={f}>{f}</option>)}
+      </select>
+      <button onClick={onNewFile} type="button">New File</button>
+      <button onClick={onDeleteFile} type="button">Delete Current File</button>
+    </div>
+  );
+
+  function onNewFile() {
+    let name = prompt("Insert name");
+    if (!name) return;
+
+    // Make sure the file is in the root directory so imports between files work
+    if (!name.startsWith("/")) {
+      name = "/" + name;
+    }
+
+    // The file also ought to have an extension in all cases
+    if (!name.includes(".")) {
+      name += ".ts";
+    }
+
+    props.onChange(name);
+  }
+
+  function onDeleteFile() {
+    props.onChange(undefined);
+  }
+
+  function onChangeFile(event: React.ChangeEvent<HTMLSelectElement>) {
+    props.onChange(event.target.value);
+  }
+}

--- a/src/components/Options.tsx
+++ b/src/components/Options.tsx
@@ -4,7 +4,6 @@ import {
   type CompilerApi,
   type CompilerPackageNames,
   compilerVersionCollection,
-  type ScriptKind,
   type ScriptTarget,
 } from "../compiler/index.js";
 import { useOnClickOutside } from "../hooks/index.js";
@@ -34,7 +33,6 @@ export function Options(props: OptionsProps) {
       <div className="menu" hidden={!showOptionsMenu}>
         {getCompilerVersions()}
         {getTreeMode()}
-        {getScriptKind()}
         {getScriptTarget()}
         {getBindingEnabled()}
         {getShowFactoryCode()}
@@ -74,20 +72,6 @@ export function Options(props: OptionsProps) {
       </select>
     );
     return <Option name="Tree mode" value={selection} />;
-  }
-
-  function getScriptKind() {
-    const { api } = props;
-    if (api == null) {
-      return undefined;
-    }
-    return getEnumOption(
-      "Script kind",
-      "ts.ScriptKind",
-      api.ScriptKind,
-      props.options.scriptKind,
-      (value) => onChange({ scriptKind: value as ScriptKind }),
-    );
   }
 
   function getScriptTarget() {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -5,3 +5,4 @@ export * from "./Options.js";
 export * from "./PropertiesViewer.js";
 export * from "./Spinner.js";
 export * from "./TreeViewer.js";
+export * from "./FilesControl.js";

--- a/src/constants/actions.ts
+++ b/src/constants/actions.ts
@@ -15,3 +15,9 @@ export type SET_OPTIONS = typeof SET_OPTIONS;
 
 export const OS_THEME_CHANGE = "OS_THEME_CHANGE";
 export type OS_THEME_CHANGE = typeof OS_THEME_CHANGE;
+
+export const SET_CURRENT_FILE = "SET_CURRENT_FILE";
+export type SET_CURRENT_FILE = typeof SET_CURRENT_FILE;
+
+export const DELETE_CURRENT_FILE = "DELETE_CURRENT_FILE";
+export type DELETE_CURRENT_FILE = typeof DELETE_CURRENT_FILE;

--- a/src/reducers/index.tsx
+++ b/src/reducers/index.tsx
@@ -1,5 +1,5 @@
 import type { AllActions } from "../actions/index.js";
-import { type CompilerApi, type CompilerPackageNames, convertOptions, createSourceFile } from "../compiler/index.js";
+import { type CompilerApi, type CompilerPackageNames, convertOptions, createSourceFiles } from "../compiler/index.js";
 import type { CodeEditorTheme } from "../components/index.js";
 import { actions as actionNames } from "./../constants/index.js";
 import type { OptionsState, StoreState } from "../types/index.js";
@@ -37,12 +37,48 @@ export function appReducer(
         ...state,
         options: convertOptions(state.compiler == null ? undefined : state.compiler.api, action.api, state.options),
       };
-      fillNewSourceFileState(newState.options.compilerPackageName, action.api, newState, state.code, state.options);
-      urlSaver.updateUrl(state.code);
+      fillNewSourceFileState(
+        newState.options.compilerPackageName,
+        action.api,
+        newState,
+        state.options,
+      );
+      urlSaver.updateUrl(state.files);
       return newState;
     }
     case actionNames.SET_CODE: {
-      return { ...state, code: action.code };
+      return {
+        ...state,
+        files: {
+          ...state.files,
+          [state.currentFile]: action.code,
+        },
+      };
+    }
+    case actionNames.SET_CURRENT_FILE: {
+      return {
+        ...state,
+        currentFile: action.file,
+        files: {
+          ...state.files,
+          [action.file]: state.files[action.file] ?? "",
+        },
+      };
+    }
+    case actionNames.DELETE_CURRENT_FILE: {
+      const filesWithoutCurrent = { ...state.files };
+      delete filesWithoutCurrent[state.currentFile];
+      let newCurrentFile = Object.keys(filesWithoutCurrent)[0];
+      if (!newCurrentFile) {
+        newCurrentFile = "/code.ts";
+        filesWithoutCurrent[newCurrentFile] = "";
+      }
+
+      return {
+        ...state,
+        currentFile: newCurrentFile,
+        files: filesWithoutCurrent,
+      };
     }
     case actionNames.SET_OPTIONS: {
       return {
@@ -82,15 +118,14 @@ function fillNewSourceFileState(
   compilerPackageName: CompilerPackageNames,
   api: CompilerApi,
   state: StoreState,
-  code: string,
   options: OptionsState,
 ) {
-  const { sourceFile, bindingTools } = createSourceFile(api, code, options.scriptTarget, options.scriptKind);
+  const { sourceFiles, bindingTools } = createSourceFiles(api, state.files, options.scriptTarget);
   state.compiler = {
     packageName: compilerPackageName,
     api,
-    sourceFile,
+    sourceFile: sourceFiles[state.currentFile],
     bindingTools,
-    selectedNode: sourceFile,
+    selectedNode: sourceFiles[state.currentFile],
   };
 }

--- a/src/types/index.tsx
+++ b/src/types/index.tsx
@@ -3,14 +3,14 @@ import type {
   CompilerPackageNames,
   Node,
   Program,
-  ScriptKind,
   ScriptTarget,
   SourceFile,
   TypeChecker,
 } from "../compiler/index.js";
 
 export interface StoreState {
-  code: string;
+  currentFile: string;
+  files: Record<string, string>;
   options: OptionsState;
   apiLoadingState: ApiLoadingState;
   compiler: CompilerState | undefined;
@@ -34,7 +34,6 @@ export interface OptionsState {
   compilerPackageName: CompilerPackageNames;
   treeMode: TreeMode;
   scriptTarget: ScriptTarget;
-  scriptKind: ScriptKind;
   bindingEnabled: boolean;
   showFactoryCode: boolean;
   showInternals: boolean;

--- a/src/utils/UrlSaver.ts
+++ b/src/utils/UrlSaver.ts
@@ -1,6 +1,29 @@
 import { compressToEncodedURIComponent, decompressFromEncodedURIComponent } from "lz-string";
 
 export class UrlSaver {
+  getUrlFiles(): Record<string, string> {
+    if (document.location.hash && document.location.hash.startsWith("#files")) {
+      try {
+        const code = document.location.hash.replace("#files/", "").trim();
+        const files = JSON.parse(decompressFromEncodedURIComponent(code) || "{}"); // will be null on error
+
+        for (const key in Object.keys(files)) {
+          if (typeof files[key] !== "string") {
+            delete files[key];
+          }
+        }
+
+        if (Object.keys(files).length !== 0) {
+          return files;
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    }
+
+    return { "/code.ts": this.getUrlCode() };
+  }
+
   getUrlCode() {
     if (document.location.hash && document.location.hash.startsWith("#code")) {
       try {
@@ -14,11 +37,12 @@ export class UrlSaver {
     return "";
   }
 
-  updateUrl(code: string) {
-    if (code.length === 0) {
+  updateUrl(files: Record<string, string>) {
+    const hash = JSON.stringify(files);
+    if (hash.length === 2) {
       updateLocationHash("");
     } else {
-      updateLocationHash(`code/${compressToEncodedURIComponent(code)}`);
+      updateLocationHash(`files/${compressToEncodedURIComponent(hash)}`);
     }
 
     function updateLocationHash(locationHash: string) {

--- a/src/utils/UrlSaver.ts
+++ b/src/utils/UrlSaver.ts
@@ -38,11 +38,11 @@ export class UrlSaver {
   }
 
   updateUrl(files: Record<string, string>) {
-    const hash = JSON.stringify(files);
-    if (hash.length === 2) {
+    const serializedFiles = JSON.stringify(files);
+    if (serializedFiles.length === 2) {
       updateLocationHash("");
     } else {
-      updateLocationHash(`files/${compressToEncodedURIComponent(hash)}`);
+      updateLocationHash(`files/${compressToEncodedURIComponent(serializedFiles)}`);
     }
 
     function updateLocationHash(locationHash: string) {


### PR DESCRIPTION
Resolves #100

This is probably far from being good code. I recently ran into an issue where I wanted to debug something that required multiple files, so I hacked together some support for multiple files. The UX for the files bar could probably use some work, but was good enough for my needs.

<img width="1200" height="396" alt="image" src="https://github.com/user-attachments/assets/7ef6bd13-9767-4627-a78b-af9878b9efd6" />

TypeScript will detect ScriptKind from the file extension, and I didn't want to deal with the UI for letting it be set when creating a file (it'd be very confusing to accidentally create a file with ScriptKind.TS when the extension shows .tsx), so I also removed that option as it wasn't being used anywhere. There  might be some use case for setting this manually that I'm unaware of, but I've never needed it.