### PR TITLE
Show TypeScript 7.0 at the top of the version selector

### DIFF
--- a/scripts/addTypeScriptVersions.ts
+++ b/scripts/addTypeScriptVersions.ts
@@ -7,9 +7,9 @@ const versions = await getTypeScriptVersionsToInstall();
 for (const version of versions) {
   await npmInstallTypeScriptVersion(version);
 }
-// Note: no `next` install and no >= 7.0.0 versions — TypeScript 7.0+ is the Go port
-// (tsgo), which the app runs from WebAssembly instead of the npm package. The nightly
-// tsgo build is added to the version list separately (see src/compiler/tsgo/tsgoVersion.ts).
+// Note: no >= 7.0.0 versions — TypeScript 7.0+ is the Go port (tsgo), which the app runs
+// from WebAssembly instead of the npm package. The tsgo builds are added to the version
+// list separately (see src/compiler/tsgo/tsgoVersion.ts).
 
 async function npmInstallTypeScriptVersion(version: string) {
   console.log(`Installing Typescript ${version}...`);

--- a/src/compiler/tsgo/tsgoVersion.ts
+++ b/src/compiler/tsgo/tsgoVersion.ts
@@ -54,10 +54,17 @@ export const tsgoBuilds: TsgoBuild[] = [
   },
 ];
 
-/** The version selector's full list: the npm-installed versions plus the tsgo builds. */
+/**
+ * The version selector's full list: the tsgo release, the npm-installed versions,
+ * then the tsgo nightly.
+ *
+ * The list reads newest to oldest, so the tsgo release goes at the top (though it's
+ * not the default selection, see AppContext) and the nightly stays at the very bottom.
+ */
 export const appCompilerVersions: { packageName: AnyCompilerPackageName; label: string }[] = [
+  ...toSelectorItems(tsgoBuilds.filter((build) => build.id !== "nightly")),
   ...compilerVersionCollection.map((v) => ({ packageName: v.packageName, label: v.version })),
-  ...tsgoBuilds.map((build) => ({ packageName: build.packageName, label: build.label })),
+  ...toSelectorItems(tsgoBuilds.filter((build) => build.id === "nightly")),
 ];
 
 /** Whether this compiler runs via the tsgo/wasm infrastructure (vs the npm typescript). */
@@ -71,4 +78,8 @@ export function getTsgoBuild(packageName: TsgoPackageName): TsgoBuild {
     throw new Error(`Unknown tsgo build: ${packageName}`);
   }
   return build;
+}
+
+function toSelectorItems(builds: TsgoBuild[]) {
+  return builds.map((build) => ({ packageName: build.packageName, label: build.label }));
 }

--- a/src/components/Options.tsx
+++ b/src/components/Options.tsx
@@ -57,16 +57,18 @@ export function Options(props: OptionsProps) {
   }
 
   function getTreeMode() {
-    // tsgo nodes only support forEachChild (no getChildren), so don't offer it there
-    const tsgo = isTsgo(props.options.compilerPackageName);
+    // tsgo nodes only support forEachChild (no getChildren), so there's nothing to choose
+    if (isTsgo(props.options.compilerPackageName)) {
+      return undefined;
+    }
     const selection = (
       <select
         id="treeMode"
-        value={tsgo ? TreeMode.forEachChild : props.options.treeMode}
+        value={props.options.treeMode}
         onChange={(event) => onChange({ treeMode: parseInt(event.target.value, 10) as TreeMode })}
       >
         <option value={TreeMode.forEachChild}>node.forEachChild(child =&gt; ...)</option>
-        {!tsgo && <option value={TreeMode.getChildren}>node.getChildren()</option>}
+        <option value={TreeMode.getChildren}>node.getChildren()</option>
       </select>
     );
     return <Option name="Tree mode" value={selection} />;


### PR DESCRIPTION
Moves the TypeScript 7.0 (tsgo) release build to the top of the version dropdown instead of the bottom, so it reads newest-to-oldest like the rest of the list. The nightly build stays at the very bottom.

The default selection is unaffected — it comes from `compilerVersionCollection[0]`, not from the first entry of the selector list, so TypeScript 7.0 is still not selected by default.

Also hides the "Tree mode" option when a tsgo version is selected. It only ever offered `forEachChild` there (tsgo nodes have no `getChildren()`), so it was a single-option select. Behavior is unchanged: `getChildrenFunction` already falls back to `forEachChild` for nodes without `getChildren`, so a saved `getChildren` tree mode still renders correctly after switching to tsgo.
