### PR TITLE
Vertically center the header title and options button

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -61,9 +61,13 @@ body,
 #AppHeader {
   background-color: var(--header-background);
   color: var(--text-color);
-  padding: 10px;
+  /* center the title and options button against each other rather than
+     padding the box and letting each land wherever its own height puts it */
+  display: flex;
+  align-items: center;
+  padding: 0 10px;
   width: 100%;
-  height: 50px;
+  height: 44px;
 }
 
 #AppBody {
@@ -94,13 +98,8 @@ a:visited {
 }
 
 #title {
-  float: left;
-}
-
-.clearfix::after {
-  content: "";
-  clear: both;
-  display: table;
+  /* overrides the shared h2 bottom margin, which would push the title off center */
+  margin: 0;
 }
 
 .verticallyCenter {
@@ -151,7 +150,7 @@ a:visited {
 /* Options */
 
 #options {
-  float: right;
+  margin-left: auto;
 }
 
 #options #optionsButton {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ export function App() {
 
   return (
     <div id="App" data-theme={state.editorTheme}>
-      <header id="AppHeader" className="clearfix">
+      <header id="AppHeader">
         <h2 id="title">TypeScript AST Viewer</h2>
         <components.Options
           api={compiler == null ? undefined : compiler.api}


### PR DESCRIPTION
The top header had noticeably more space below the title than above it.

The cause wasn't the padding itself. The header laid out `#title` and `#options` with floats inside a 50px box with `padding: 10px`. The options button happened to land centered (10px above, 10px below), but the title was top-aligned in the content box *and* carried the shared `h2 { margin-bottom: 5px }` rule — so it measured 10px above and 17px below, and sat ~3.5px above the button's optical center.

| | before (top / bottom) | after |
|---|---|---|
| `#title` | 10px / 17px | 10.5px / 10.5px |
| options button | 10px / 10px | 7px / 7px |

Changes:
- `#AppHeader` becomes `display: flex; align-items: center` with `padding: 0 10px`, so both children center against each other regardless of their own heights.
- Height 50px → 44px, returning 6px to the editor panes.
- `#title` gets `margin: 0` to override the shared `h2` margin.
- `#options` uses `margin-left: auto` instead of `float: right`.
- The `clearfix` class is removed — it existed only for these floats, and its `::after` would otherwise become a stray flex item (it silently breaks `justify-content` on the header).

Verified in both light and dark themes, and confirmed the options dropdown still anchors correctly under the button.