### PR TITLE
Content-hash the tsgo wasm file names

### DIFF
--- a/scripts/buildTsgo.ts
+++ b/scripts/buildTsgo.ts
@@ -27,6 +27,8 @@ interface BuildResult {
   commitDate: string;
   /** The version the app displays: the npm release for a tag, else the commit date. */
   version: string;
+  /** This build's wasm in `public/`, content-hashed (see buildWasm). */
+  wasmFileName: string;
 }
 
 await $`git --version`.quiet();
@@ -57,10 +59,24 @@ await writeBuildInfo(builds);
 async function buildVersion(id: string, ref: string): Promise<BuildResult> {
   const { repoDir, commit, commitDate } = await checkoutTsgo(ref);
   await vendorClient(id, repoDir, commit);
-  if (!skipWasm && (wasmOnly == null || wasmOnly === id)) {
-    await buildWasm(id, repoDir);
+  const built = !skipWasm && (wasmOnly == null || wasmOnly === id);
+  const wasmFileName = built ? await buildWasm(id, repoDir) : await findExistingWasm(id);
+  return { id, ref, commit, commitDate, version: getVersionFromRef(ref) ?? commitDate, wasmFileName };
+}
+
+/**
+ * The wasm already in `public/` for a build, for the runs that don't rebuild it
+ * (`--skip-wasm`, or `--wasm-only` for the other build). Falls back to the unhashed name
+ * so the generated module still type-checks on a tree that has never been built — CI
+ * vendors the clients and runs `deno task check` before the wasms exist.
+ */
+async function findExistingWasm(id: string): Promise<string> {
+  for await (const entry of readDirOrEmpty(wasmOutDir)) {
+    if (entry.isFile && new RegExp(`^tsgo-${id}-[0-9a-f]+\\.wasm$`).test(entry.name)) {
+      return entry.name;
+    }
   }
-  return { id, ref, commit, commitDate, version: getVersionFromRef(ref) ?? commitDate };
+  return `tsgo-${id}.wasm`;
 }
 
 /**
@@ -113,11 +129,17 @@ async function checkoutTsgo(ref: string): Promise<{ repoDir: string; commit: str
   return { repoDir, commit, commitDate };
 }
 
-/** Record which typescript-go commit each build came from, for the app to display. */
+/** Record which typescript-go commit each build came from and which wasm it produced. */
 async function writeBuildInfo(builds: BuildResult[]) {
   const outPath = path.join(root, "src/compiler/tsgo/tsgoBuildInfo.generated.ts");
   const entries = builds.map((result) => {
-    const info = { ref: result.ref, commit: result.commit, commitDate: result.commitDate, version: result.version };
+    const info = {
+      ref: result.ref,
+      commit: result.commit,
+      commitDate: result.commitDate,
+      version: result.version,
+      wasmFileName: result.wasmFileName,
+    };
     return `  ${result.id}: ${JSON.stringify(info)},\n`;
   });
   await $.path(outPath).writeText(
@@ -244,18 +266,52 @@ async function* walkTs(dir: string): AsyncGenerator<string> {
   }
 }
 
-async function buildWasm(id: string, repoDir: string) {
+/**
+ * Build one wasm into `public/`, named with a hash of its own bytes, and return the file
+ * name for the app to fetch.
+ *
+ * The hash is the cache-busting: vite content-hashes the JS it emits but copies `public/`
+ * verbatim, so a fixed name lets a browser (or a CDN) pair a freshly deployed client with
+ * the wasm it cached days ago. That is survivable while the two only differ in compiler
+ * version, and fatal the moment the module's exports change — which is exactly what
+ * happened when this became a reactor. A name that changes with the bytes makes the two
+ * impossible to mix: a client only ever asks for the wasm it was built against.
+ */
+async function buildWasm(id: string, repoDir: string): Promise<string> {
   await installReactor(repoDir);
-  $.logStep("Building", `tsgo-${id}.wasm (GOOS=wasip1 GOARCH=wasm) — this takes a few minutes`);
+  $.logStep("Building", `tsgo-${id} wasm (GOOS=wasip1 GOARCH=wasm) — this takes a few minutes`);
   await $.path(wasmOutDir).ensureDir();
-  const outFile = path.join(wasmOutDir, `tsgo-${id}.wasm`);
+  const tempFile = path.join(wasmOutDir, `tsgo-${id}.building`);
   // -buildmode=c-shared makes a reactor: `_initialize` plus the //go:wasmexport
   // entry points, instead of a `_start` that runs a server loop and never returns.
-  await $`go build -buildmode=c-shared -o ${outFile} ./cmd/tsgo-wasm`
+  await $`go build -buildmode=c-shared -o ${tempFile} ./cmd/tsgo-wasm`
     .cwd(repoDir)
     .env({ GOOS: "wasip1", GOARCH: "wasm", GOTOOLCHAIN: "auto" });
-  const size = (await $.path(outFile).stat())!.size;
-  $.log(`Wrote ${outFile} (${(size / 1024 / 1024).toFixed(0)} MB)`);
+
+  const bytes = await Deno.readFile(tempFile);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  const hash = Array.from(new Uint8Array(digest).slice(0, 5), (b) => b.toString(16).padStart(2, "0")).join("");
+  const fileName = `tsgo-${id}-${hash}.wasm`;
+
+  // drop this build's older wasms, so `public/` doesn't accumulate 40MB per rebuild.
+  // Anchored on `.wasm` so it can't match the `.building` file being renamed in below.
+  const stale = new RegExp(`^tsgo-${id}(-[0-9a-f]+)?\\.wasm$`);
+  for await (const entry of readDirOrEmpty(wasmOutDir)) {
+    if (entry.isFile && entry.name !== fileName && stale.test(entry.name)) {
+      await Deno.remove(path.join(wasmOutDir, entry.name));
+    }
+  }
+  await Deno.rename(tempFile, path.join(wasmOutDir, fileName));
+  $.log(`Wrote ${fileName} (${(bytes.length / 1024 / 1024).toFixed(0)} MB)`);
+  return fileName;
+}
+
+async function* readDirOrEmpty(dir: string): AsyncGenerator<Deno.DirEntry> {
+  try {
+    yield* Deno.readDir(dir);
+  } catch {
+    // no public/ yet — nothing built
+  }
 }
 
 /**

--- a/src/compiler/tsgo/tsgoVersion.ts
+++ b/src/compiler/tsgo/tsgoVersion.ts
@@ -27,7 +27,8 @@ export interface TsgoBuild {
   version: string;
   /** How the version selector names this build. */
   label: string;
-  /** This build's wasm in `public/` (see scripts/buildTsgo.ts). */
+  /** This build's wasm in `public/` — content-hashed, so a cached wasm can never be
+   * paired with a client built against different exports (see scripts/buildTsgo.ts). */
   wasmFileName: string;
   /** Loads the client vendored from the same commit as `wasmFileName`. */
   importVendor: () => Promise<TsgoVendor>;
@@ -39,7 +40,7 @@ export const tsgoBuilds: TsgoBuild[] = [
     packageName: `${TSGO_PACKAGE_PREFIX}${TSGO_BUILDS.stable.version}`,
     version: TSGO_BUILDS.stable.version,
     label: TSGO_BUILDS.stable.version,
-    wasmFileName: "tsgo-stable.wasm",
+    wasmFileName: TSGO_BUILDS.stable.wasmFileName,
     importVendor: toVendorLoader(() => import("./vendor/stable/mod.ts")),
   },
   {
@@ -49,7 +50,7 @@ export const tsgoBuilds: TsgoBuild[] = [
     // typescript-go commit on main it was built from
     version: TSGO_BUILDS.nightly.commitDate,
     label: `nightly (${TSGO_BUILDS.nightly.commitDate})`,
-    wasmFileName: "tsgo-nightly.wasm",
+    wasmFileName: TSGO_BUILDS.nightly.wasmFileName,
     importVendor: toVendorLoader(() => import("./vendor/nightly/mod.ts")),
   },
 ];

--- a/src/compiler/tsgo/tsgoWasmSession.ts
+++ b/src/compiler/tsgo/tsgoWasmSession.ts
@@ -64,9 +64,27 @@ export async function createTsgoWasmSession(options: TsgoWasmSessionOptions): Pr
   wasi.initialize(instance as unknown as Parameters<WASI["initialize"]>[0]);
 
   const exports = instance.exports as unknown as ReactorExports;
+  assertReactor(exports);
   const session = new ReactorSession(exports);
   session.createSession(options.cwd ?? "/");
   return session;
+}
+
+/**
+ * Fail with the missing export named, rather than `undefined is not a function` several
+ * calls later. Reaching this means the wasm and the client disagree about the module's
+ * shape — which the content-hashed file name is meant to make impossible, so it's a
+ * broken deployment rather than a stale cache.
+ */
+function assertReactor(exports: ReactorExports): void {
+  const required = ["_initialize", "create_session", "get_request_buffer", "handle_request", "response_ptr"] as const;
+  const missing = required.filter((name) => typeof exports[name] !== "function");
+  if (missing.length > 0) {
+    throw new Error(
+      `This tsgo wasm isn't a reactor build — it's missing ${missing.join(", ")}. ` +
+        `The wasm and the app were built from different sources.`,
+    );
+  }
 }
 
 class ReactorSession implements TsgoWasmSession {


### PR DESCRIPTION
Fixes the `TypeError: this.exports.get_request_buffer is not a function` seen on ts-ast-viewer.com after #177 shipped.

## Cause

Vite content-hashes the JS it emits, but copies `public/` verbatim — so `tsgo-nightly.wasm` and `tsgo-stable.wasm` kept the same URLs across every deploy. A returning visitor could pair a freshly deployed client with a wasm their browser (or a CDN) cached days earlier.

That was survivable while the two only differed in compiler version. It became fatal the moment #177 changed the module from an `_start` command to a reactor: the new client calls `get_request_buffer`, the cached wasm only has `_start`. A hard refresh fixed it, which is exactly the signature of a stale cached asset.

## Fix

The file name now carries a hash of the wasm's own bytes:

```
public/tsgo-nightly-5ad03b651d.wasm
public/tsgo-stable-cc7d2680a5.wasm
```

`buildTsgo` writes the name into `tsgoBuildInfo.generated.ts`, which `tsgoVersion.ts` already reads for the rest of each build's identity. A client only ever asks for the wasm it was built against, so the two can't be mixed regardless of what any cache holds.

Details:
- Older wasms for the same build are deleted, so `public/` doesn't grow by ~40MB per rebuild.
- Runs that don't rebuild a wasm (`--skip-wasm`, `--wasm-only` for the other build) reuse the name already on disk, falling back to the unhashed name on a tree that has never been built — CI vendors clients and runs `deno task check` before any wasm exists.
- The Go build is deterministic: rebuilding an unchanged ref produces the same hash, so returning users don't re-download 40MB for an unchanged nightly. (Confirmed — an aborted and a completed build of the same commit produced identical hashes.)

Also asserts the reactor's exports at instantiation, so any future mismatch names the missing export rather than failing several calls later.

## Testing

- `deno task check`, `deno lint`, `deno test -A`, `deno task build` pass.
- `--skip-wasm` verified to preserve the hashed names rather than reverting them.
- Verified against the **production** build (`deno task preview`, which is where the bug appeared): the only wasm requested is `tsgo-nightly-5ad03b651d.wasm`, the tree renders, `Type: string` / `Symbol: greeting`, `checker.typeToString(checker.getTypeAtLocation(node))` returns `"string"` from the console, and there are no console errors.
